### PR TITLE
Escape facet terms.

### DIFF
--- a/src/main/webapps/default/www/sru/index.gtpl
+++ b/src/main/webapps/default/www/sru/index.gtpl
@@ -34,7 +34,7 @@ xmlDeclaration()
               'facet:terms' {
                 facet.buckets.each { bucket ->
                   'facet:term' {
-                    'facet:actualTerm' "${bucket.term}"
+                    'facet:actualTerm' org.xbib.content.xml.util.XMLUtil.escape("${bucket.term}")
                     'facet:requestUrl' "${bucket.requestUrl}"
                     'facet:count' "${bucket.count}"
                   }


### PR DESCRIPTION
We have facet terms that contain XML reserved characters. They need to be escaped when generating the SRU response.

Hope that's the right spot; I wasn't able to test the fix.